### PR TITLE
Namespace + Constexpr + Const

### DIFF
--- a/examples/button/button.ino
+++ b/examples/button/button.ino
@@ -8,7 +8,7 @@ void setup() {
   gpio.begin();      // use default address 0
 
   gpio.pinMode(0, INPUT);
-  gpio.pinSetPull(0, PCAL9535A::PULL_TYPE::UP);  // turn on the internal pullup
+  gpio.pinSetPull(0, PCAL9535A::PullSetting::UP);  // turn on the internal pullup
 
   pinMode(13, OUTPUT);  // use the p13 LED
 }

--- a/examples/button/button.ino
+++ b/examples/button/button.ino
@@ -8,7 +8,7 @@ void setup() {
   gpio.begin();      // use default address 0
 
   gpio.pinMode(0, INPUT);
-  gpio.pinSetPull(0, PULL_UP);  // turn on the internal pullup
+  gpio.pinSetPull(0, PCAL9535A::PULL_TYPE::UP);  // turn on the internal pullup
 
   pinMode(13, OUTPUT);  // use the p13 LED
 }

--- a/examples/button/button.ino
+++ b/examples/button/button.ino
@@ -2,7 +2,7 @@
 #include <Wire.h>
 #include "PCAL9535A.h"
 
-PCAL9535A gpio;
+PCAL9535A::PCAL9535A gpio;
   
 void setup() {  
   gpio.begin();      // use default address 0

--- a/examples/readall/readall.ino
+++ b/examples/readall/readall.ino
@@ -2,7 +2,7 @@
 #include <Wire.h>
 #include "PCAL9535A.h"
 
-PCAL9535A gpio;
+PCAL9535A::PCAL9535A gpio;
   
 void setup() {  
   Serial.begin(250000);

--- a/examples/toggle/toggle.ino
+++ b/examples/toggle/toggle.ino
@@ -2,7 +2,7 @@
 #include <Wire.h>
 #include "PCAL9535A.h"
 
-PCAL9535A gpio;
+PCAL9535A::PCAL9535A gpio;
   
 void setup() {  
   gpio.begin();      // use default address 0

--- a/src/PCAL9535A.cpp
+++ b/src/PCAL9535A.cpp
@@ -195,14 +195,14 @@ void PCAL9535A::portSetOutputMode(uint8_t port, uint8_t mode) {
 /**
  * Convert a given pin (0 - 15) to a port bit number (0 - 7)
  */
-uint8_t PCAL9535A::pinToBit(uint8_t pin) {
+uint8_t PCAL9535A::pinToBit(uint8_t pin) const {
 	return pin % 8;
 }
 
 /**
  * Select the register for port 0 or port 1 depending on the given pin
  */
-uint8_t PCAL9535A::pinToReg(uint8_t pin, uint8_t port0addr, uint8_t port1addr) {
+uint8_t PCAL9535A::pinToReg(uint8_t pin, uint8_t port0addr, uint8_t port1addr) const {
 	return (pin < 8) ? port0addr : port1addr;
 }
 

--- a/src/PCAL9535A.cpp
+++ b/src/PCAL9535A.cpp
@@ -20,8 +20,8 @@ void PCAL9535A::begin(uint8_t addr) {
 	Wire.begin();
 
 	// set all pins as inputs
-	writeRegister(PCAL9535A_P0_CONFIG, 0xff);
-	writeRegister(PCAL9535A_P1_CONFIG, 0xff);
+	writeRegister(RegisterAddress::P0_CONFIG, 0xff);
+	writeRegister(RegisterAddress::P1_CONFIG, 0xff);
 }
 
 /**
@@ -35,7 +35,7 @@ void PCAL9535A::begin(void) {
  * Sets the pin mode to either INPUT or OUTPUT
  */
 void PCAL9535A::pinMode(uint8_t pin, uint8_t mode) {
-	updateRegisterBit(pin, (mode == INPUT ? 1 : 0), PCAL9535A_P0_CONFIG, PCAL9535A_P1_CONFIG);
+	updateRegisterBit(pin, (mode == INPUT ? 1 : 0), RegisterAddress::P0_CONFIG, RegisterAddress::P1_CONFIG);
 }
 
 /**
@@ -43,7 +43,7 @@ void PCAL9535A::pinMode(uint8_t pin, uint8_t mode) {
  */
 uint8_t PCAL9535A::readGPIO(uint8_t port) {
 	Wire.beginTransmission(PCAL9535A_ADDRESS | _i2caddr);
-	Wire.write(port == 0 ? PCAL9535A_P0_INPUT : PCAL9535A_P1_INPUT);
+	Wire.write(port == 0 ? RegisterAddress::P0_INPUT : RegisterAddress::P1_INPUT);
 	Wire.endTransmission();
 	Wire.requestFrom(PCAL9535A_ADDRESS | _i2caddr, 1);
 	return Wire.read();
@@ -58,7 +58,7 @@ uint16_t PCAL9535A::readGPIO16() {
 
 	// read the current GPIO inputs
 	Wire.beginTransmission(PCAL9535A_ADDRESS | _i2caddr);
-	Wire.write(PCAL9535A_P0_INPUT);
+	Wire.write(RegisterAddress::P0_INPUT);
 	Wire.endTransmission();
 
 	Wire.requestFrom(PCAL9535A_ADDRESS | _i2caddr, 2);
@@ -75,7 +75,7 @@ uint16_t PCAL9535A::readGPIO16() {
  */
 void PCAL9535A::writeGPIO(uint8_t port, uint8_t val) {
 	Wire.beginTransmission(PCAL9535A_ADDRESS | _i2caddr);
-	Wire.write(port == 0 ? PCAL9535A_P0_OUTPUT : PCAL9535A_P1_OUTPUT);
+	Wire.write(port == 0 ? RegisterAddress::P0_OUTPUT : RegisterAddress::P1_OUTPUT);
 	Wire.write(val);
 	Wire.endTransmission();
 }
@@ -85,7 +85,7 @@ void PCAL9535A::writeGPIO(uint8_t port, uint8_t val) {
  */
 void PCAL9535A::writeGPIO16(uint16_t val) {
 	Wire.beginTransmission(PCAL9535A_ADDRESS | _i2caddr);
-	Wire.write(PCAL9535A_P0_OUTPUT);
+	Wire.write(RegisterAddress::P0_OUTPUT);
 	Wire.write(val & 0xFF);
 	Wire.write(val >> 8);
 	Wire.endTransmission();
@@ -94,7 +94,7 @@ void PCAL9535A::writeGPIO16(uint16_t val) {
 void PCAL9535A::digitalWrite(uint8_t pin, uint8_t val) {
 	uint8_t gpio;
 	uint8_t bit = pinToBit(pin);
-	uint8_t regAddr = pinToReg(pin, PCAL9535A_P0_OUTPUT, PCAL9535A_P1_OUTPUT);
+	RegisterAddress regAddr = pinToReg(pin, RegisterAddress::P0_OUTPUT, RegisterAddress::P1_OUTPUT);
 
 	// read the current GPIO state, so we can modify only this one pin
 	gpio = readRegister(regAddr);
@@ -108,31 +108,31 @@ void PCAL9535A::digitalWrite(uint8_t pin, uint8_t val) {
 
 uint8_t PCAL9535A::digitalRead(uint8_t pin) {
 	uint8_t bit = pinToBit(pin);
-	uint8_t regAddr = pinToReg(pin, PCAL9535A_P0_INPUT, PCAL9535A_P1_INPUT);
+	RegisterAddress regAddr = pinToReg(pin, RegisterAddress::P0_INPUT, RegisterAddress::P1_INPUT);
 	return (readRegister(regAddr) >> bit) & 0x1;
 }
 
 /**
  * Set the pull-up/down resistor for a given pin
  */
-void PCAL9535A::pinSetPull(uint8_t pin, PULL_TYPE pull) {
-	updateRegisterBit(pin, ((pull == PULL_TYPE::NONE) ? PCAL9535A_PULLENA_DISABLED : PCAL9535A_PULLENA_ENABLED), PCAL9535A_P0_PULLENA, PCAL9535A_P1_PULLENA);
-	updateRegisterBit(pin, ((pull == PULL_TYPE::UP) ? PCAL9535A_PULLSEL_PULLUP : PCAL9535A_PULLSEL_PULLDOWN), PCAL9535A_P0_PULLSEL, PCAL9535A_P1_PULLSEL);	
+void PCAL9535A::pinSetPull(uint8_t pin, PullSetting pull) {
+	updateRegisterBit(pin, ((pull == PullSetting::NONE) ? RegisterValues_PULLENA::DISABLED : RegisterValues_PULLENA::ENABLED), RegisterAddress::P0_PULLENA, RegisterAddress::P1_PULLENA);
+	updateRegisterBit(pin, ((pull == PullSetting::UP) ? RegisterValues_PULLSEL::PULLUP : RegisterValues_PULLSEL::PULLDOWN), RegisterAddress::P0_PULLSEL, RegisterAddress::P1_PULLSEL);	
 }
 
 /**
  * Sets the output pin drive strength
  */
 void PCAL9535A::pinSetDriveStrength(uint8_t pin, uint8_t str) {
-	uint8_t regAddr;
+	RegisterAddress regAddr;
 	uint8_t regValue;
 
 	if (pinToBit(pin) < 4) {
-		regAddr = pinToReg(pin, PCAL9535A_P0_DRVSTR1, PCAL9535A_P1_DRVSTR1);
+		regAddr = pinToReg(pin, RegisterAddress::P0_DRVSTR1, RegisterAddress::P1_DRVSTR1);
 	}
 	else
 	{
-		regAddr = pinToReg(pin, PCAL9535A_P0_DRVSTR2, PCAL9535A_P1_DRVSTR2);
+		regAddr = pinToReg(pin, RegisterAddress::P0_DRVSTR2, RegisterAddress::P1_DRVSTR2);
 	}
 
  	regValue = readRegister(regAddr);
@@ -145,14 +145,14 @@ void PCAL9535A::pinSetDriveStrength(uint8_t pin, uint8_t str) {
  * Sets the input pin polarity inversion
  */
 void PCAL9535A::pinSetInputInversion(uint8_t pin, bool invert) {
-	updateRegisterBit(pin, (invert ? 1 : 0), PCAL9535A_P0_POLINV, PCAL9535A_P1_POLINV);
+	updateRegisterBit(pin, (invert ? 1 : 0), RegisterAddress::P0_POLINV, RegisterAddress::P1_POLINV);
 }
 
 /**
  * Sets the input pin polarity inversion
  */
 void PCAL9535A::pinSetInputLatch(uint8_t pin, bool latch) {
-	updateRegisterBit(pin, (latch ? 1 : 0), PCAL9535A_P0_ILATCH, PCAL9535A_P1_ILATCH);
+	updateRegisterBit(pin, (latch ? 1 : 0), RegisterAddress::P0_ILATCH, RegisterAddress::P1_ILATCH);
 }
 
 /**
@@ -160,16 +160,16 @@ void PCAL9535A::pinSetInputLatch(uint8_t pin, bool latch) {
  */
 void PCAL9535A::pinSetInterruptEnabled(uint8_t pin, bool enabled) {
 
-	updateRegisterBit(pin, (enabled ? 1 : 0), PCAL9535A_P0_INTMASK, PCAL9535A_P1_INTMASK);
+	updateRegisterBit(pin, (enabled ? 1 : 0), RegisterAddress::P0_INTMASK, RegisterAddress::P1_INTMASK);
 }
 
 uint8_t PCAL9535A::getLastInterruptPin() {
 	uint8_t intf;
 
-	intf = readRegister(PCAL9535A_P0_INTSTAT);
+	intf = readRegister(RegisterAddress::P0_INTSTAT);
 	for(int i = 0; i < 8; i++) if (bitRead(intf, i)) return i;
 
-	intf = readRegister(PCAL9535A_P1_INTSTAT);
+	intf = readRegister(RegisterAddress::P1_INTSTAT);
 	for(int i = 0; i < 8; i++) if (bitRead(intf, i)) return i + 8;
 
 	return PCAL9535A_INT_ERR;
@@ -187,7 +187,7 @@ uint8_t PCAL9535A::getInterruptPinValue() {
 }
 
 void PCAL9535A::portSetOutputMode(uint8_t port, uint8_t mode) {
-	uint8_t regAddr = PCAL9535A_OUTPUT_CONF;
+	RegisterAddress regAddr = RegisterAddress::OUTPUT_CONF;
 	uint8_t regValue = readRegister(regAddr);
 	bitWrite(regValue, (port == 0 ? 0 : 1), (mode & 0x01));
 	writeRegister(regAddr, regValue);
@@ -203,17 +203,17 @@ uint8_t PCAL9535A::pinToBit(uint8_t pin) const {
 /**
  * Select the register for port 0 or port 1 depending on the given pin
  */
-uint8_t PCAL9535A::pinToReg(uint8_t pin, uint8_t port0addr, uint8_t port1addr) const {
-	return (pin < 8) ? port0addr : port1addr;
+RegisterAddress PCAL9535A::pinToReg(uint8_t pin, RegisterAddress port0, RegisterAddress port1) const {
+	return (pin < 8) ? port0 : port1;
 }
 
 /**
  * Reads a given register
  */
-uint8_t PCAL9535A::readRegister(uint8_t addr) {
+uint8_t PCAL9535A::readRegister(RegisterAddress reg) {
 	// read the current GPINTEN
 	Wire.beginTransmission(PCAL9535A_ADDRESS | _i2caddr);
-	Wire.write(addr);
+	Wire.write(reg);
 	Wire.endTransmission();
 	Wire.requestFrom(PCAL9535A_ADDRESS | _i2caddr, 1);
 	return Wire.read();
@@ -222,10 +222,10 @@ uint8_t PCAL9535A::readRegister(uint8_t addr) {
 /**
  * Writes a given register
  */
-void PCAL9535A::writeRegister(uint8_t regAddr, uint8_t regValue) {
+void PCAL9535A::writeRegister(RegisterAddress reg, uint8_t regValue) {
 	// Write the register
 	Wire.beginTransmission(PCAL9535A_ADDRESS | _i2caddr);
-	Wire.write(regAddr);
+	Wire.write(reg);
 	Wire.write(regValue);
 	Wire.endTransmission();
 }
@@ -235,9 +235,9 @@ void PCAL9535A::writeRegister(uint8_t regAddr, uint8_t regValue) {
  * - Reads the current register value
  * - Writes the new register value
  */
-void PCAL9535A::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t port0addr, uint8_t port1addr) {
+void PCAL9535A::updateRegisterBit(uint8_t pin, uint8_t pValue, RegisterAddress port0, RegisterAddress port1) {
 	uint8_t regValue;
-	uint8_t regAddr = pinToReg(pin, port0addr, port1addr);
+	RegisterAddress regAddr = pinToReg(pin, port0, port1);
 	uint8_t bit = pinToBit(pin);
 	regValue = readRegister(regAddr);
 

--- a/src/PCAL9535A.cpp
+++ b/src/PCAL9535A.cpp
@@ -7,6 +7,8 @@
 #include "PCAL9535A.h"
 #include <Arduino.h>
 
+namespace PCAL9535A {
+
 /**
  * Initializes the PCAL9535A given its HW address, see datasheet for address selection.
  */
@@ -242,3 +244,5 @@ void PCAL9535A::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t port0addr
 	bitWrite(regValue, bit, pValue);
 	writeRegister(regAddr, regValue);
 }
+
+} // namespace PCAL9535A

--- a/src/PCAL9535A.cpp
+++ b/src/PCAL9535A.cpp
@@ -6,6 +6,7 @@
 
 #include "PCAL9535A.h"
 #include <Arduino.h>
+#include <Wire.h>
 
 namespace PCAL9535A {
 

--- a/src/PCAL9535A.cpp
+++ b/src/PCAL9535A.cpp
@@ -114,9 +114,9 @@ uint8_t PCAL9535A::digitalRead(uint8_t pin) {
 /**
  * Set the pull-up/down resistor for a given pin
  */
-void PCAL9535A::pinSetPull(uint8_t pin, uint8_t pull) {
-	updateRegisterBit(pin, ((pull == PULL_NONE) ? PCAL9535A_PULLENA_DISABLED : PCAL9535A_PULLENA_ENABLED), PCAL9535A_P0_PULLENA, PCAL9535A_P1_PULLENA);
-	updateRegisterBit(pin, ((pull == PULL_UP) ? PCAL9535A_PULLSEL_PULLUP : PCAL9535A_PULLSEL_PULLDOWN), PCAL9535A_P0_PULLSEL, PCAL9535A_P1_PULLSEL);	
+void PCAL9535A::pinSetPull(uint8_t pin, PULL_TYPE pull) {
+	updateRegisterBit(pin, ((pull == PULL_TYPE::NONE) ? PCAL9535A_PULLENA_DISABLED : PCAL9535A_PULLENA_ENABLED), PCAL9535A_P0_PULLENA, PCAL9535A_P1_PULLENA);
+	updateRegisterBit(pin, ((pull == PULL_TYPE::UP) ? PCAL9535A_PULLSEL_PULLUP : PCAL9535A_PULLSEL_PULLDOWN), PCAL9535A_P0_PULLSEL, PCAL9535A_P1_PULLSEL);	
 }
 
 /**

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -14,44 +14,55 @@ namespace PCAL9535A {
 constexpr int PCAL9535A_ADDRESS = 0x20;
 
 // registers
-constexpr int PCAL9535A_P0_INPUT    = 0x00;
-constexpr int PCAL9535A_P0_OUTPUT   = 0x02;
-constexpr int PCAL9535A_P0_POLINV   = 0x04;
-constexpr int PCAL9535A_P0_CONFIG   = 0x06;
-constexpr int PCAL9535A_P0_DRVSTR1  = 0x40;
-constexpr int PCAL9535A_P0_DRVSTR2  = 0x41;
-constexpr int PCAL9535A_P0_ILATCH   = 0x44;
-constexpr int PCAL9535A_P0_PULLENA  = 0x46;
-constexpr int PCAL9535A_P0_PULLSEL  = 0x48;
-constexpr int PCAL9535A_P0_INTMASK  = 0x4A;
-constexpr int PCAL9535A_P0_INTSTAT  = 0x4C;
+enum RegisterAddress {
+  P0_INPUT    = 0x00,
+  P0_OUTPUT   = 0x02,
+  P0_POLINV   = 0x04,
+  P0_CONFIG   = 0x06,
+  P0_DRVSTR1  = 0x40,
+  P0_DRVSTR2  = 0x41,
+  P0_ILATCH   = 0x44,
+  P0_PULLENA  = 0x46,
+  P0_PULLSEL  = 0x48,
+  P0_INTMASK  = 0x4A,
+  P0_INTSTAT  = 0x4C,
+  P1_INPUT    = 0x01,
+  P1_OUTPUT   = 0x03,
+  P1_POLINV   = 0x05,
+  P1_CONFIG   = 0x07,
+  P1_DRVSTR1  = 0x42,
+  P1_DRVSTR2  = 0x43,
+  P1_ILATCH   = 0x45,
+  P1_PULLENA  = 0x47,
+  P1_PULLSEL  = 0x49,
+  P1_INTMASK  = 0x4B,
+  P1_INTSTAT  = 0x4D,
+  OUTPUT_CONF = 0x4F
+};
 
-constexpr int PCAL9535A_P1_INPUT    = 0x01;
-constexpr int PCAL9535A_P1_OUTPUT   = 0x03;
-constexpr int PCAL9535A_P1_POLINV   = 0x05;
-constexpr int PCAL9535A_P1_CONFIG   = 0x07;
-constexpr int PCAL9535A_P1_DRVSTR1  = 0x42;
-constexpr int PCAL9535A_P1_DRVSTR2  = 0x43;
-constexpr int PCAL9535A_P1_ILATCH   = 0x45;
-constexpr int PCAL9535A_P1_PULLENA  = 0x47;
-constexpr int PCAL9535A_P1_PULLSEL  = 0x49;
-constexpr int PCAL9535A_P1_INTMASK  = 0x4B;
-constexpr int PCAL9535A_P1_INTSTAT  = 0x4D;
+enum RegisterValues_DRVSTR {
+  _25 = 0x00,
+  _50 = 0x01,
+  _75 = 0x10,
+  _100 = 0x11
+};
 
-constexpr int PCAL9535A_OUTPUT_CONF = 0x4F;
+enum RegisterValues_PULLENA {
+  DISABLED = 0x00,
+  ENABLED = 0x01
+};
 
-constexpr int PCAL9535A_DRVSTR_25   = 0x00;
-constexpr int PCAL9535A_DRVSTR_50   = 0x01;
-constexpr int PCAL9535A_DRVSTR_75   = 0x10;
-constexpr int PCAL9535A_DRVSTR_100  = 0x11;
-constexpr int PCAL9535A_PULLENA_DISABLED  = 0x00;
-constexpr int PCAL9535A_PULLENA_ENABLED   = 0x01;
-constexpr int PCAL9535A_PULLSEL_PULLDOWN  = 0x00;
-constexpr int PCAL9535A_PULLSEL_PULLUP    = 0x01;
-constexpr int PCAL9535A_OUTPUT_CONF_PP    = 0x00;
-constexpr int PCAL9535A_OUTPUT_CONF_OD    = 0x01;
+enum RegisterValues_PULLSEL {
+  PULLDOWN = 0x00,
+  PULLUP = 0x01
+};
 
-enum class PULL_TYPE {
+enum RegisterValues_OUTPUTCONF {
+  PUSHPULL = 0x00,
+  OPENDRAIN = 0x01
+};
+
+enum class PullSetting {
   NONE,
   UP,
   DOWN
@@ -70,7 +81,7 @@ public:
   void pinMode(uint8_t pin, uint8_t mode);
   void digitalWrite(uint8_t pin, uint8_t val);
   uint8_t digitalRead(uint8_t pin);
-  void pinSetPull(uint8_t pin, PULL_TYPE pull);
+  void pinSetPull(uint8_t pin, PullSetting pull);
   void pinSetDriveStrength(uint8_t pin, uint8_t str);
   void pinSetInputInversion(uint8_t pin, bool invert);
   void pinSetInputLatch(uint8_t pin, bool latch);
@@ -83,10 +94,10 @@ public:
   uint8_t _i2caddr;
 
   uint8_t pinToBit(uint8_t pin) const;
-  uint8_t pinToReg(uint8_t pin, uint8_t port0addr, uint8_t port1addr) const;
-  uint8_t readRegister(uint8_t addr);
-  void writeRegister(uint8_t addr, uint8_t value);
-  void updateRegisterBit(uint8_t p, uint8_t pValue, uint8_t port0addr, uint8_t port1addr);
+  RegisterAddress pinToReg(uint8_t pin, RegisterAddress port0, RegisterAddress port1) const;
+  uint8_t readRegister(RegisterAddress register);
+  void writeRegister(RegisterAddress register, uint8_t value);
+  void updateRegisterBit(uint8_t p, uint8_t pValue, RegisterAddress port0, RegisterAddress port1);
 
 };
 

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -14,7 +14,7 @@ namespace PCAL9535A {
 constexpr int PCAL9535A_ADDRESS = 0x20;
 
 // registers
-enum RegisterAddress {
+enum RegisterAddress : uint8_t {
   P0_INPUT    = 0x00,
   P0_OUTPUT   = 0x02,
   P0_POLINV   = 0x04,
@@ -40,29 +40,29 @@ enum RegisterAddress {
   OUTPUT_CONF = 0x4F
 };
 
-enum RegisterValues_DRVSTR {
+enum RegisterValues_DRVSTR : uint8_t  {
   _25 = 0x00,
   _50 = 0x01,
   _75 = 0x10,
   _100 = 0x11
 };
 
-enum RegisterValues_PULLENA {
+enum RegisterValues_PULLENA : uint8_t  {
   DISABLED = 0x00,
   ENABLED = 0x01
 };
 
-enum RegisterValues_PULLSEL {
+enum RegisterValues_PULLSEL : uint8_t  {
   PULLDOWN = 0x00,
   PULLUP = 0x01
 };
 
-enum RegisterValues_OUTPUTCONF {
+enum RegisterValues_OUTPUTCONF : uint8_t  {
   PUSHPULL = 0x00,
   OPENDRAIN = 0x01
 };
 
-enum class PullSetting {
+enum class PullSetting : uint8_t  {
   NONE,
   UP,
   DOWN

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -11,51 +11,51 @@
 
 namespace PCAL9535A {
 
-#define PCAL9535A_ADDRESS 0x20
+constexpr int PCAL9535A_ADDRESS = 0x20;
 
 // registers
-#define PCAL9535A_P0_INPUT    0x00
-#define PCAL9535A_P0_OUTPUT   0x02
-#define PCAL9535A_P0_POLINV   0x04
-#define PCAL9535A_P0_CONFIG   0x06
-#define PCAL9535A_P0_DRVSTR1  0x40
-#define PCAL9535A_P0_DRVSTR2  0x41
-#define PCAL9535A_P0_ILATCH   0x44
-#define PCAL9535A_P0_PULLENA  0x46
-#define PCAL9535A_P0_PULLSEL  0x48
-#define PCAL9535A_P0_INTMASK  0x4A
-#define PCAL9535A_P0_INTSTAT  0x4C
+constexpr int PCAL9535A_P0_INPUT    = 0x00;
+constexpr int PCAL9535A_P0_OUTPUT   = 0x02;
+constexpr int PCAL9535A_P0_POLINV   = 0x04;
+constexpr int PCAL9535A_P0_CONFIG   = 0x06;
+constexpr int PCAL9535A_P0_DRVSTR1  = 0x40;
+constexpr int PCAL9535A_P0_DRVSTR2  = 0x41;
+constexpr int PCAL9535A_P0_ILATCH   = 0x44;
+constexpr int PCAL9535A_P0_PULLENA  = 0x46;
+constexpr int PCAL9535A_P0_PULLSEL  = 0x48;
+constexpr int PCAL9535A_P0_INTMASK  = 0x4A;
+constexpr int PCAL9535A_P0_INTSTAT  = 0x4C;
 
-#define PCAL9535A_P1_INPUT    0x01
-#define PCAL9535A_P1_OUTPUT   0x03
-#define PCAL9535A_P1_POLINV   0x05
-#define PCAL9535A_P1_CONFIG   0x07
-#define PCAL9535A_P1_DRVSTR1  0x42
-#define PCAL9535A_P1_DRVSTR2  0x43
-#define PCAL9535A_P1_ILATCH   0x45
-#define PCAL9535A_P1_PULLENA  0x47
-#define PCAL9535A_P1_PULLSEL  0x49
-#define PCAL9535A_P1_INTMASK  0x4B
-#define PCAL9535A_P1_INTSTAT  0x4D
+constexpr int PCAL9535A_P1_INPUT    = 0x01;
+constexpr int PCAL9535A_P1_OUTPUT   = 0x03;
+constexpr int PCAL9535A_P1_POLINV   = 0x05;
+constexpr int PCAL9535A_P1_CONFIG   = 0x07;
+constexpr int PCAL9535A_P1_DRVSTR1  = 0x42;
+constexpr int PCAL9535A_P1_DRVSTR2  = 0x43;
+constexpr int PCAL9535A_P1_ILATCH   = 0x45;
+constexpr int PCAL9535A_P1_PULLENA  = 0x47;
+constexpr int PCAL9535A_P1_PULLSEL  = 0x49;
+constexpr int PCAL9535A_P1_INTMASK  = 0x4B;
+constexpr int PCAL9535A_P1_INTSTAT  = 0x4D;
 
-#define PCAL9535A_OUTPUT_CONF 0x4F
+constexpr int PCAL9535A_OUTPUT_CONF = 0x4F;
 
-#define PCAL9535A_DRVSTR_25   0x00
-#define PCAL9535A_DRVSTR_50   0x01
-#define PCAL9535A_DRVSTR_75   0x10
-#define PCAL9535A_DRVSTR_100  0x11
-#define PCAL9535A_PULLENA_DISABLED  0x00
-#define PCAL9535A_PULLENA_ENABLED   0x01
-#define PCAL9535A_PULLSEL_PULLDOWN  0x00
-#define PCAL9535A_PULLSEL_PULLUP    0x01
-#define PCAL9535A_OUTPUT_CONF_PP    0x00
-#define PCAL9535A_OUTPUT_CONF_OD    0x01
+constexpr int PCAL9535A_DRVSTR_25   = 0x00;
+constexpr int PCAL9535A_DRVSTR_50   = 0x01;
+constexpr int PCAL9535A_DRVSTR_75   = 0x10;
+constexpr int PCAL9535A_DRVSTR_100  = 0x11;
+constexpr int PCAL9535A_PULLENA_DISABLED  = 0x00;
+constexpr int PCAL9535A_PULLENA_ENABLED   = 0x01;
+constexpr int PCAL9535A_PULLSEL_PULLDOWN  = 0x00;
+constexpr int PCAL9535A_PULLSEL_PULLUP    = 0x01;
+constexpr int PCAL9535A_OUTPUT_CONF_PP    = 0x00;
+constexpr int PCAL9535A_OUTPUT_CONF_OD    = 0x01;
 
-#define PULL_NONE 0
-#define PULL_UP   1
-#define PULL_DOWN 2
+constexpr int PULL_NONE = 0;
+constexpr int PULL_UP   = 1;
+constexpr int PULL_DOWN = 2;
 
-#define PCAL9535A_INT_ERR 255
+constexpr int PCAL9535A_INT_ERR = 255;
 
 class PCAL9535A {
 public:

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -80,8 +80,8 @@ public:
  private:
   uint8_t _i2caddr;
 
-  uint8_t pinToBit(uint8_t pin);
-  uint8_t pinToReg(uint8_t pin, uint8_t port0addr, uint8_t port1addr);
+  uint8_t pinToBit(uint8_t pin) const;
+  uint8_t pinToReg(uint8_t pin, uint8_t port0addr, uint8_t port1addr) const;
   uint8_t readRegister(uint8_t addr);
   void writeRegister(uint8_t addr, uint8_t value);
   void updateRegisterBit(uint8_t p, uint8_t pValue, uint8_t port0addr, uint8_t port1addr);

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -51,9 +51,11 @@ constexpr int PCAL9535A_PULLSEL_PULLUP    = 0x01;
 constexpr int PCAL9535A_OUTPUT_CONF_PP    = 0x00;
 constexpr int PCAL9535A_OUTPUT_CONF_OD    = 0x01;
 
-constexpr int PULL_NONE = 0;
-constexpr int PULL_UP   = 1;
-constexpr int PULL_DOWN = 2;
+enum class PULL_TYPE {
+  NONE,
+  UP,
+  DOWN
+};
 
 constexpr int PCAL9535A_INT_ERR = 255;
 
@@ -68,7 +70,7 @@ public:
   void pinMode(uint8_t pin, uint8_t mode);
   void digitalWrite(uint8_t pin, uint8_t val);
   uint8_t digitalRead(uint8_t pin);
-  void pinSetPull(uint8_t pin, uint8_t pull);
+  void pinSetPull(uint8_t pin, PULL_TYPE pull);
   void pinSetDriveStrength(uint8_t pin, uint8_t str);
   void pinSetInputInversion(uint8_t pin, bool invert);
   void pinSetInputLatch(uint8_t pin, bool latch);

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -7,7 +7,7 @@
 #ifndef _PCAL9535A_H_
 #define _PCAL9535A_H_
 
-#include <Wire.h>
+#include <stdint.h>
 
 namespace PCAL9535A {
 

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -9,6 +9,8 @@
 
 #include <Wire.h>
 
+namespace PCAL9535A {
+
 #define PCAL9535A_ADDRESS 0x20
 
 // registers
@@ -86,5 +88,6 @@ public:
 
 };
 
+} // namespace PCAL9535A
 
 #endif


### PR DESCRIPTION
- Wrap library in PCAL9535A namespace so that register defines/consts don't pollute main project.
- Change register defines to constexpr (should be better practice / type safety)
- Mark class methods that can be const as const