### PR TITLE
Run CI Action daily

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: PlatformIO CI
 
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Running CI daily might be useful to detect some potential problems (deleted/renamed dependencies, etc.). 

Seeing as this is a rather static project and could be months between PRs, could be useful to have a more frequent check.

Overhead is quite low so can't see any harm in this.