### PR TITLE
Remove unnecessary Arduino include

### DIFF
--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -8,7 +8,6 @@
 #define _PCAL9535A_H_
 
 #include <stdint.h>
-#include <Arduino.h>
 
 namespace PCAL9535A {
 


### PR DESCRIPTION
This include should not be necessary and may cause conflicts by dragging in unnecessary Arduino macros etc.