### PR TITLE
Fix Drive Strength being applied wrongly

### DIFF
--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -343,7 +343,7 @@ public:
   }
 
  private:
-  uint8_t _i2caddr;
+  uint8_t _i2caddr{PCAL9535A_ADDRESS};
   WIRE& mWire;
 
   /**

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -100,7 +100,7 @@ public:
   explicit PCAL9535A(WIRE& wire) : mWire(wire) {}
   /**
    * Initializes the PCAL9535A given its HW address, see datasheet for address selection.
-   * /param addr Address of PCAL9535A (0 - 7)
+   * \param addr Address of PCAL9535A (0 - 7)
    */
   void begin(HardwareAddress addr)
   {
@@ -375,7 +375,7 @@ public:
    */
   uint8_t readRegister(RegisterAddress reg)
   {
-    // read the current GPINTEN
+    // read the register
     mWire.beginTransmission(_i2caddr);
     mWire.write(static_cast<uint8_t>(reg));
     mWire.endTransmission();

--- a/src/PCAL9535A.h
+++ b/src/PCAL9535A.h
@@ -59,10 +59,10 @@ enum class RegisterAddress : uint8_t {
 };
 
 enum class DriveStrength : uint8_t  {
-  P25 = 0x00,
-  P50 = 0x01,
-  P75 = 0x10,
-  P100 = 0x11
+  P25 = 0b00,
+  P50 = 0b01,
+  P75 = 0b10,
+  P100 = 0b11
 };
 
 enum class RegisterValues_PULLENA : uint8_t  {
@@ -254,6 +254,7 @@ public:
     }
 
     regValue = readRegister(regAddr);
+    regValue &= ~(0x03 << ((pin % 4) * 2));
     regValue |= (static_cast<uint8_t>(strength) & 0x03) << ((pin % 4) * 2);
 
     writeRegister(regAddr, regValue);


### PR DESCRIPTION
Register values were wrong and register wasn't being cleared correctly. Limited drive strength to only ever being 25 or 50% I think.